### PR TITLE
feat(builders): implement custom builders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # compiled output
 /dist
+**/dist
 /tmp
 /out-tsc
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@
 
 /dist
 /coverage
+# schematic templates
+**/*__tmpl__

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,8 @@
 {
   "recommendations": [
     "ms-vscode.vscode-typescript-tslint-plugin",
-    "esbenp.prettier-vscode"
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "DigitalBrainstem.javascript-ejs-support"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "files.associations": {
+    "*__tmpl__": "html",
+  }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "format:check": "nx format:check",
     "workspace-schematic": "nx workspace-schematic",
     "dep-graph": "nx dep-graph",
-    "help": "nx help"
+    "help": "nx help",
+    "workspace-builders:build": "rm -rf tools/builders/dist && tsc -p tools/builders"
   },
   "private": true,
   "dependencies": {
@@ -39,6 +40,7 @@
     "@nrwl/react": "8.9.0",
     "@nrwl/web": "8.9.0",
     "@nrwl/workspace": "8.9.0",
+    "@types/dateformat": "3.0.1",
     "@types/eslint": "6.1.3",
     "@types/jest": "24.0.9",
     "@types/node": "~8.9.4",
@@ -47,6 +49,7 @@
     "@typescript-eslint/eslint-plugin": "2.3.2",
     "@typescript-eslint/parser": "2.3.2",
     "confusing-browser-globals": "1.0.9",
+    "dateformat": "3.0.3",
     "dotenv": "6.2.0",
     "eslint": "6.1.0",
     "eslint-config-prettier": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@babel/cli": "7.7.7",
     "@babel/preset-react": "7.7.4",
+    "@babel/register": "7.7.4",
     "@nrwl/cli": "8.9.0",
     "@nrwl/eslint-plugin-nx": "8.9.0",
     "@nrwl/jest": "8.9.0",
@@ -40,6 +41,7 @@
     "@nrwl/react": "8.9.0",
     "@nrwl/web": "8.9.0",
     "@nrwl/workspace": "8.9.0",
+    "@types/babel__core": "7.1.3",
     "@types/dateformat": "3.0.1",
     "@types/eslint": "6.1.3",
     "@types/jest": "24.0.9",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "workspace-schematic": "nx workspace-schematic",
     "dep-graph": "nx dep-graph",
     "help": "nx help",
+    "workspace-builders:generate": "yarn workspace-schematic workspace-builder",
     "workspace-builders:build": "rm -rf tools/builders/dist && tsc -p tools/builders"
   },
   "private": true,

--- a/tools/builders/README.md
+++ b/tools/builders/README.md
@@ -1,0 +1,157 @@
+# Builders
+
+> This folder contains a package with custom builders for nx architect
+
+Currently [`nx` doesn't provide any schematics/npm-command to generate/run custom builders](https://github.com/nrwl/nx/issues/2211) (unlike for schematics). For that reason, we need to [follow standard Angular CLI builder guide about how build our own builders](https://angular.io/guide/cli-builder), with a bit of tweaking to be easily used within `nx`.
+
+> hopefully in the future it will be implemented natively (it's indeed possible and I have idea in my mind how it could be achieved...)
+
+**Folder(Package structure:**
+
+```
+├── command/  // builder
+├── file/     // builder
+├── babel-register.config.js // babel config for dynamic transpilation
+├── builders.json // schema for all custom builders
+├── package.json // standard npm package with dependencies
+└── tsconfig.json
+```
+
+> For excellent intro into builders please read this [excellent blog post](https://medium.com/angular-in-depth/angular-cli-under-the-hood-builders-demystified-v2-e73ee0f2d811).
+
+After reading above article, we know that custom builder/s need to be a standard namespaced npm package/packages. To follow best practices and custom schematics implementation within nx, all we need is just one npm package, that defines multiple builders.
+
+In our case:
+
+- name: `@custom-builders/builders`
+- builders: `multiple` (defined within [`builders.json`](./builders.json))
+
+**Builders Usage**
+
+Builder packages can be used in 2 ways:
+
+1. by referencing package name with builder
+
+```json
+{
+  "architect": {
+    "file": {
+      "builder": "@custom-builders/builders:file",
+      "options": {}
+    }
+  }
+}
+```
+
+**Where:**
+
+`"@custom-builders/builders:file"`
+
+- `@custom-builders/builders` is our package name
+- `:file` is our file builder
+
+2. relative path to local package (we will use this method, as our custom builders are only for our build needs)
+
+```json
+{
+  "architect": {
+    "file": {
+      "builder": "./tools/builders:file",
+      "options": {}
+    }
+  }
+}
+```
+
+**Where:**
+
+`"./tools/builders:file"`
+
+- `./tools/builders` is relative path to our builders package
+- `:file` is our file builder
+
+## Custom Builders
+
+Custom builders within `nx` can be implemented and run via `nx` with 3 approaches:
+
+1. vanilla js (no build step)
+2. manual compilation (build step needed)
+3. dynamic compilation (no build step)
+
+Following two builders demonstrate approach 2 and 3.
+
+> **Why not 1.?**
+>
+> Builder implementation uses a lot of generics. It would be cumbersome to write them with vanilla js and get proper type-safety and DX.
+
+### [command](./command/schema.json)
+
+> uses manual compilation
+
+**Builder Schema**
+
+```json
+{
+  "command": {
+    "implementation": "./dist/command/index.js",
+    "schema": "./command/schema.json",
+    "description": "Runs any command line in the operating system."
+  }
+}
+```
+
+As you can see, we use compilation output as an `"implementation"` reference of our `command` builder
+
+```json
+"implementation": "./dist/command/index.js",
+```
+
+instead of real implementation which resides within `./command/index.ts`.
+
+That means, before running any `architect` target, we need to have our builder physically present on our filesystem (compiled via typescript `yarn tsc -p tools/builders`).
+
+That can be quite cumbersome indeed... Anyways this should be used when we wanna publish our builders to npm and use it from npm registry.
+
+**Pros**
+
+- easily publishable to npm
+
+**Cons**
+
+- manual compilation needed before executing `nx run`
+
+### [file](./file/schema.json)
+
+> uses dynamic compilation
+
+**Builder Schema**
+
+```json
+{
+  "file": {
+    "implementation": "./file/index.js",
+    "schema": "./file/schema.json",
+    "description": "Builder that creates timestamp"
+  }
+}
+```
+
+As you can see, we use vanilla js barrel file as `"implementation"` reference of our `command` builder.
+
+You might be thinking that we are not using typescript, but we are indeed! Our `index.js` is leveraging `@babel/register` to dynamically transpile all our typescript files (in this case, our builder implementation within [`./file.impl.ts`](./file.impl.ts)), thus everything is type safe... even that vanilla index.js (_checkJs_) ;).
+
+Last required thing is to adhere to standard builder api, which needs default export of builder implementation. In our case it looks like following:
+
+```js
+// file.impl is TypeScript file that exports Builder as default export!
+exports.default = require('./file.impl').default;
+```
+
+**Pros**
+
+- no manual input needed
+- low effort to publish as npm package
+
+**Cons**
+
+- `nx run` wont fail if there are any type errors present within implementation. (this is not a big deal as on CI, we'll run tsc on affected files anyway)

--- a/tools/builders/babel-register.config.js
+++ b/tools/builders/babel-register.config.js
@@ -1,0 +1,22 @@
+/** @type {import('types/babel__register').Config} */
+const config = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 'current'
+        }
+      }
+    ],
+    '@babel/preset-typescript'
+  ],
+  /**
+   * This is needed so pirate properly resolves paths when not called from root
+   * @see https://github.com/babel/babel/issues/10349
+   */
+  cwd: __dirname,
+  extensions: ['.jsx', '.js', '.ts', '.tsx']
+};
+
+module.exports = config;

--- a/tools/builders/builders.json
+++ b/tools/builders/builders.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../node_modules/@angular-devkit/architect/src/builders-schema.json",
+  "builders": {
+    "command": {
+      "implementation": "./dist/command/index.js",
+      "schema": "./command/schema.json",
+      "description": "Runs any command line in the operating system."
+    },
+    "file": {
+      "implementation": "./dist/file/file.impl.js",
+      "schema": "./file/schema.json",
+      "description": "Builder that creates timestamp"
+    }
+  }
+}

--- a/tools/builders/builders.json
+++ b/tools/builders/builders.json
@@ -7,7 +7,7 @@
       "description": "Runs any command line in the operating system."
     },
     "file": {
-      "implementation": "./dist/file/file.impl.js",
+      "implementation": "./file/index.js",
       "schema": "./file/schema.json",
       "description": "Builder that creates timestamp"
     }

--- a/tools/builders/command/index.ts
+++ b/tools/builders/command/index.ts
@@ -1,0 +1,38 @@
+import {
+  BuilderOutput,
+  createBuilder,
+  BuilderContext
+} from '@angular-devkit/architect';
+import { JsonObject } from '@angular-devkit/core';
+import * as childProcess from 'child_process';
+
+import { CommandRunnerBuilderSchema } from './schema.d';
+
+interface Schema extends CommandRunnerBuilderSchema, JsonObject {}
+
+export default createBuilder(commandBuilder);
+
+export function commandBuilder(
+  options: Schema,
+  context: BuilderContext
+): Promise<BuilderOutput> {
+  return new Promise((resolve) => {
+    context.reportStatus(`Executing "${options.command}"...`);
+
+    const child = childProcess.spawn(options.command, options.args, {
+      stdio: 'pipe'
+    });
+    child.stdout.on('data', (data) => {
+      context.logger.info(data.toString());
+    });
+    child.stderr.on('data', (data) => {
+      context.logger.error(data.toString());
+    });
+
+    context.reportStatus(`Done.`);
+    child.on('close', (code) => {
+      context.logger.info('DONE!!!');
+      resolve({ success: code === 0 });
+    });
+  });
+}

--- a/tools/builders/command/schema.d.ts
+++ b/tools/builders/command/schema.d.ts
@@ -1,0 +1,4 @@
+export interface CommandRunnerBuilderSchema {
+  args?: string[];
+  command: string;
+}

--- a/tools/builders/command/schema.json
+++ b/tools/builders/command/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "CommandRunnerBuilderSchema",
+  "title": "Command Runner builder",
+  "type": "object",
+  "properties": {
+    "command": {
+      "type": "string"
+    },
+    "args": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["command"]
+}

--- a/tools/builders/file/file.impl.ts
+++ b/tools/builders/file/file.impl.ts
@@ -1,0 +1,46 @@
+import { TimestampBuilderSchema } from './schema.d';
+import {
+  BuilderContext,
+  BuilderOutput,
+  createBuilder
+} from '@angular-devkit/architect';
+import { Observable, bindNodeCallback, of } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
+import { json, getSystemPath, normalize } from '@angular-devkit/core';
+import { writeFile } from 'fs';
+import dateFormat from 'dateformat';
+
+// interface Schema extends TimestampBuilderSchema, json.JsonObject {}
+// export function createTimestamp(
+//   { path, format }: Schema,
+//   { workspaceRoot, logger }: BuilderContext
+// ): Observable<BuilderOutput> {}
+// export default createBuilder(createTimestamp);
+
+export default createBuilder<json.JsonObject & TimestampBuilderSchema>(
+  createTimestamp
+);
+
+export function createTimestamp(
+  { path, format }: TimestampBuilderSchema,
+  { workspaceRoot, logger }: BuilderContext
+): Observable<BuilderOutput> {
+  const timestampFileName = `${getSystemPath(
+    normalize(workspaceRoot)
+  )}/${path}`;
+  const writeFileObservable = bindNodeCallback(writeFile);
+  const timestampLogger = logger.createChild('Timestamp');
+
+  return writeFileObservable(
+    timestampFileName,
+    dateFormat(new Date(), format)
+  ).pipe(
+    map<void, BuilderOutput>(() => ({ success: true })),
+    tap(() => timestampLogger.info('Timestamp created')),
+    catchError((err) => {
+      timestampLogger.error('Failed to create timestamp', err);
+
+      return of<BuilderOutput>({ success: false });
+    })
+  );
+}

--- a/tools/builders/file/file.impl.ts
+++ b/tools/builders/file/file.impl.ts
@@ -1,4 +1,3 @@
-import { TimestampBuilderSchema } from './schema.d';
 import {
   BuilderContext,
   BuilderOutput,
@@ -10,19 +9,14 @@ import { json, getSystemPath, normalize } from '@angular-devkit/core';
 import { writeFile } from 'fs';
 import dateFormat from 'dateformat';
 
-// interface Schema extends TimestampBuilderSchema, json.JsonObject {}
-// export function createTimestamp(
-//   { path, format }: Schema,
-//   { workspaceRoot, logger }: BuilderContext
-// ): Observable<BuilderOutput> {}
-// export default createBuilder(createTimestamp);
+import { TimestampBuilderSchema } from './schema.d';
 
-export default createBuilder<json.JsonObject & TimestampBuilderSchema>(
-  createTimestamp
-);
+interface Schema extends TimestampBuilderSchema, json.JsonObject {}
+
+export default createBuilder(createTimestamp);
 
 export function createTimestamp(
-  { path, format }: TimestampBuilderSchema,
+  { path, format }: Schema,
   { workspaceRoot, logger }: BuilderContext
 ): Observable<BuilderOutput> {
   const timestampFileName = `${getSystemPath(

--- a/tools/builders/file/index.js
+++ b/tools/builders/file/index.js
@@ -1,0 +1,7 @@
+const babelRegister = require('@babel/register');
+const config = require('../babel-register.config');
+
+babelRegister(config);
+
+// REQUIRED BUILDER API: re-export default as default
+exports.default = require('./file.impl').default;

--- a/tools/builders/file/schema.d.ts
+++ b/tools/builders/file/schema.d.ts
@@ -1,0 +1,4 @@
+export interface TimestampBuilderSchema {
+  format: string;
+  path: string;
+}

--- a/tools/builders/file/schema.json
+++ b/tools/builders/file/schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "TimestampBuilderSchema",
+  "title": "Timestamp builder",
+  "description": "Timestamp builder options",
+  "type": "object",
+  "properties": {
+    "format": {
+      "type": "string",
+      "description": "Timestamp format",
+      "default": "dd/mm/yyyy"
+    },
+    "path": {
+      "type": "string",
+      "description": "Path to the timestamp file",
+      "default": "./timestamp"
+    }
+  }
+}

--- a/tools/builders/package.json
+++ b/tools/builders/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@custom-builders/builders",
+  "version": "1.0.0",
+  "description": "Builder for Command Runner",
+  "builders": "builders.json",
+  "devDependencies": {
+    "@angular-devkit/architect": "^1.0.0"
+  }
+}

--- a/tools/builders/tsconfig.json
+++ b/tools/builders/tsconfig.json
@@ -1,11 +1,18 @@
 {
   "extends": "../tsconfig.tools.json",
   "compilerOptions": {
-    // "allowJs": true,
-    // "checkJs": true,
+    "allowJs": true,
+    "checkJs": true,
     "alwaysStrict": true,
     "rootDir": ".",
     "outDir": "./dist"
   },
-  "include": ["**/*.ts"]
+  "include": [
+    "**/*.ts",
+    "**/*.js"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/tools/builders/tsconfig.json
+++ b/tools/builders/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.tools.json",
+  "compilerOptions": {
+    // "allowJs": true,
+    // "checkJs": true,
+    "alwaysStrict": true,
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["**/*.ts"]
+}

--- a/tools/schematics/README.md
+++ b/tools/schematics/README.md
@@ -1,0 +1,42 @@
+# Schematics
+
+## API
+
+- [Guide](https://angular.io/guide/schematics)
+- [API (@angular-devkit/schematics)](https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/schematics/README.md)
+
+### `template<T>(options: T)`
+
+> applies both `contentTemplate()` and `pathTemplate()` to the entire `Tree`.
+>
+> Check [whole template modules source](https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/schematics/src/rules/template.ts)
+
+![template interpolation](https://user-images.githubusercontent.com/1223799/71835156-28cba200-30b1-11ea-9a6e-7ae0f02d99f5.png)
+
+## Recipes:
+
+- [nx](https://connect.nrwl.io/app/cookbook/4in0DECnRZILfXVMh7Mdtr)
+
+## FAQ
+
+- **What's the difference between defining schematic as a factory vs standard function?**
+
+```ts
+export default function(schema: any): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    return tree;
+  };
+}
+```
+
+vs
+
+```ts
+export default function(schema: any): Rule {
+  return chain([
+    // ...
+  ]);
+}
+```
+
+There is no difference, return a factory if you need to access(get injected) `Tree` or `SchematicContext`. Besides that it's up to you how the implementation looks like, only restriction is to always return `Rule`.

--- a/tools/schematics/workspace-builder/files/__name__/__name__.impl.ts__tmpl__
+++ b/tools/schematics/workspace-builder/files/__name__/__name__.impl.ts__tmpl__
@@ -1,0 +1,24 @@
+
+import {
+  BuilderContext,
+  BuilderOutput,
+  createBuilder
+} from '@angular-devkit/architect';
+import { json } from '@angular-devkit/core';
+
+import { <%= utils.classify(name) %>BuilderSchema } from './schema';
+
+interface Schema extends <%= utils.classify(name) %>BuilderSchema, json.JsonObject {}
+
+export function <%= utils.camelize(name) %>BuilderHandler(
+  options: Schema,
+  context: BuilderContext
+): Promise<BuilderOutput> {
+  return new Promise((resolve) => {
+    context.logger.info('<%= name %> builder works!');
+
+    resolve({ success: true });
+  });
+}
+
+export default createBuilder(<%= utils.camelize(name) %>BuilderHandler);

--- a/tools/schematics/workspace-builder/files/__name__/index.js__tmpl__
+++ b/tools/schematics/workspace-builder/files/__name__/index.js__tmpl__
@@ -1,0 +1,7 @@
+const babelRegister = require('@babel/register');
+const config = require('../babel-register.config');
+
+babelRegister(config);
+
+// REQUIRED BUILDER API: re-export default as default
+exports.default = require('./<%= name %>.impl').default;

--- a/tools/schematics/workspace-builder/files/__name__/index.ts__tmpl__
+++ b/tools/schematics/workspace-builder/files/__name__/index.ts__tmpl__
@@ -1,0 +1,24 @@
+
+import {
+  BuilderContext,
+  BuilderOutput,
+  createBuilder
+} from '@angular-devkit/architect';
+import { json } from '@angular-devkit/core';
+
+import { <%= utils.classify(name) %>BuilderSchema } from './schema';
+
+interface Schema extends <%= utils.classify(name) %>BuilderSchema, json.JsonObject {}
+
+export function <%= utils.camelize(name) %>BuilderHandler(
+  options: Schema,
+  context: BuilderContext
+): Promise<BuilderOutput> {
+  return new Promise((resolve) => {
+    context.logger.info('<%= name %> builder works!');
+
+    resolve({ success: true });
+  });
+}
+
+export default createBuilder(<%= utils.camelize(name) %>BuilderHandler);

--- a/tools/schematics/workspace-builder/files/__name__/schema.d.ts__tmpl__
+++ b/tools/schematics/workspace-builder/files/__name__/schema.d.ts__tmpl__
@@ -1,0 +1,4 @@
+export interface <%= utils.classify(name) %>BuilderSchema {
+  command: string;
+  args?: string[];
+}

--- a/tools/schematics/workspace-builder/files/__name__/schema.json
+++ b/tools/schematics/workspace-builder/files/__name__/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "<%= utils.classify(name) %>BuilderSchema",
+  "title": "<%= name %> builder",
+  "type": "object",
+  "properties": {
+    "command": {
+      "type": "string"
+    },
+    "args": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["command"]
+}

--- a/tools/schematics/workspace-builder/index.ts
+++ b/tools/schematics/workspace-builder/index.ts
@@ -1,0 +1,91 @@
+import {
+  apply,
+  branchAndMerge,
+  chain,
+  mergeWith,
+  Rule,
+  template,
+  url,
+  move,
+  filter
+} from '@angular-devkit/schematics';
+import {
+  Schema as BuilderSchema,
+  Builder as BuilderDefinition
+} from '@angular-devkit/architect/src/builders-schema';
+import { strings as stringUtils } from '@angular-devkit/core';
+import { formatFiles, toFileName, updateJsonInTree } from '@nrwl/workspace';
+
+import { WorkspaceBuilderSchema as Schema } from './schema';
+
+type NormalizedSchema = Schema & typeof schemaDefaults;
+const schemaDefaults = {
+  autoCompile: true,
+  skipFormat: false
+};
+const workspaceBuildersRoot = 'tools/builders';
+
+export default function(schema: Schema): Rule {
+  const options = normalizeOptions(schema);
+
+  return chain([
+    branchAndMerge(
+      chain([createFiles(options), updateBuildersSchema(options)])
+    ),
+    formatFiles(options)
+  ]);
+}
+
+function createFiles(options: NormalizedSchema): Rule {
+  const templateSource = apply(url('./files'), [
+    template({
+      dot: '.',
+      tmpl: '',
+      utils: stringUtils,
+      ...options
+    }),
+    filter((filePath) => {
+      if (options.autoCompile) {
+        return !filePath.endsWith('index.ts');
+      }
+      return !filePath.endsWith('index.js') && !filePath.endsWith('impl.ts');
+    }),
+    move(workspaceBuildersRoot)
+  ]);
+
+  return mergeWith(templateSource);
+}
+
+function updateBuildersSchema(options: NormalizedSchema): Rule {
+  const builderSchemaConfig = createBuilderSchemaConfig(options);
+
+  return updateJsonInTree<BuilderSchema>(
+    `${workspaceBuildersRoot}/builders.json`,
+    (json) => {
+      json.builders[options.name] = builderSchemaConfig;
+
+      return json;
+    }
+  );
+}
+
+function createBuilderSchemaConfig(
+  options: NormalizedSchema
+): BuilderDefinition {
+  const implSource = options.autoCompile
+    ? `${options.name}/index.js`
+    : `./dist/${options.name}/index.js`;
+  const builderSchemaConfig: BuilderDefinition = {
+    description: options.description || 'Builder...',
+    implementation: implSource,
+    schema: `./${options.name}/schema.json`
+  };
+
+  return builderSchemaConfig;
+}
+
+function normalizeOptions(options: Schema): NormalizedSchema {
+  const name = toFileName(options.name);
+
+  return { ...schemaDefaults, ...options, name };
+}

--- a/tools/schematics/workspace-builder/schema.d.ts
+++ b/tools/schematics/workspace-builder/schema.d.ts
@@ -1,0 +1,20 @@
+export interface WorkspaceBuilderSchema {
+  /**
+   * Library name
+   */
+  name: string;
+  /**
+   * Use @babel/register to avoid manual compilation
+   * @default true
+   */
+  autoCompile?: boolean;
+  /**
+   * Skip formatting files
+   */
+  description?: string;
+  /**
+   * Skip formatting files
+   * @default false
+   */
+  skipFormat?: boolean;
+}

--- a/tools/schematics/workspace-builder/schema.json
+++ b/tools/schematics/workspace-builder/schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "workspace-builder",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Library name",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the workspace builder?"
+    },
+    "autoCompile": {
+      "type": "boolean",
+      "description": "use @babel/register to avoid manual compilation",
+      "default": true
+    },
+    "description": {
+      "type": "string",
+      "description": "Skip formatting files",
+      "x-prompt": "Give it some short description"
+    },
+    "skipFormat": {
+      "description": "Skip formatting files",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "required": ["name"]
+}

--- a/tools/scripts/execute.js
+++ b/tools/scripts/execute.js
@@ -1,0 +1,9 @@
+// @ts-check
+const args = process.argv.slice(2);
+
+main();
+
+function main() {
+  console.log('SCRIPT RUNNING');
+  console.log(args);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "sourceMap": true,
     "declaration": false,
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@productboard/eslint-config": ["libs/eslint-config/src/index.ts"]
+      "@productboard/eslint-config": ["libs/eslint-config/src/index.ts"],
+      "@babel/register": ["types/babel__register"]
     }
   },
   "exclude": ["node_modules", "tmp", "dist"]

--- a/types/babel__register/index.d.ts
+++ b/types/babel__register/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for @babel/register [7.x]
+// Project: https://github.com/babel/babel/tree/master/packages/babel-register, https://babeljs.io
+// Definitions by: Martin Hochel <https://github.com/hotell>
+
+import { TransformOptions } from '@babel/core';
+
+/**
+ * If you want to expose types from your module as well, you can place them in this block.
+ */
+declare namespace ConfigFn {
+  interface Config extends TransformOptions {
+    extensions?: Array<string>;
+    cache?: boolean;
+  }
+}
+
+declare const ConfigFn: (config?: ConfigFn.Config) => void;
+
+export = ConfigFn;

--- a/workspace.json
+++ b/workspace.json
@@ -1,6 +1,39 @@
 {
   "version": 1,
   "projects": {
+    "builder-test": {
+      "root": "libs/builder-test",
+      "sourceRoot": "libs/builder-test/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "timestamp": {
+          "builder": "./tools/builders:file",
+          "options": {}
+        },
+        "list": {
+          "builder": "./tools/builders:command",
+          "options": {
+            "command": "ls",
+            "args": [
+              "-la",
+              "./libs/builder-test/"
+            ]
+          }
+        },
+        "custom-scripts": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "commands": [
+              {
+                "command": "node ./tools/scripts/execute.js --prod={args.prod}"
+              }
+            ],
+            "parallel": false
+          }
+        }
+      }
+    },
     "eslint-config": {
       "root": "libs/eslint-config",
       "sourceRoot": "libs/eslint-config/src",
@@ -54,7 +87,8 @@
     },
     "@nrwl/react": {
       "application": {
-        "linter": "eslint"
+        "linter": "eslint",
+        "babel": true
       },
       "library": {
         "linter": "eslint"

--- a/yarn.lock
+++ b/yarn.lock
@@ -924,6 +924,17 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.3.2"
 
+"@babel/register@7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.7.4.tgz#45a4956471a9df3b012b747f5781cc084ee8f128"
+  integrity sha512-/fmONZqL6ZMl9KJUYajetCrID6m0xmL4odX7v+Xvoxcv0DdbP/oO0TWIeLUCHqczQ6L6njDMqmqHFy2cp3FFsA==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    lodash "^4.17.13"
+    make-dir "^2.1.0"
+    pirates "^4.0.0"
+    source-map-support "^0.5.16"
+
 "@babel/runtime-corejs3@^7.7.4":
   version "7.7.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.7.6.tgz#5b1044ea11b659d288f77190e19c62da959ed9a3"
@@ -1370,7 +1381,7 @@
   dependencies:
     esquery "^1.0.1"
 
-"@types/babel__core@^7.1.0":
+"@types/babel__core@7.1.3", "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
   integrity sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==
@@ -7495,7 +7506,7 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pirates@^4.0.1:
+pirates@^4.0.0, pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
   integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
@@ -9084,7 +9095,7 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@^0.5.5, source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.5.16, source-map-support@^0.5.5, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
   integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,6 +1408,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/dateformat@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/dateformat/-/dateformat-3.0.1.tgz#98d747a2e5e9a56070c6bf14e27bff56204e34cc"
+  integrity sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -3496,6 +3501,11 @@ data-urls@^1.0.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
+
+dateformat@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
+  integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
 debug@*, debug@4.1.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
- demonstrate how to implement custom builders
- adds thorough docs how to implement custom builders (will be published as blog post)
- use custom builders in architect targets
- add custom schematic to generate custom builders
- add custom npm script similar to `workspace-schematic` -> to generate nx custom builders `workspace-builders:generate`

Closes #3 
